### PR TITLE
Post-Callout Styling Bug Fixed

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,7 +13,7 @@ description: > # this means to ignore newlines until "baseurl:"
 
 baseurl: "" # the subpath of your site, e.g. /blog
 url: "https://rehanbutt.com" # the base hostname & protocol for your site
-version: 5.48.0
+version: 5.48.1
 version-naming: [Apricot, Blackcurrent, Coconut, Dragonfruit, Elderberry]
 
 # Build settings

--- a/_projects/cmunyc.markdown
+++ b/_projects/cmunyc.markdown
@@ -36,7 +36,7 @@ When starting this project we looked into other Carnegie Mellon campuses as well
 <div class="image-container"><img src="../img/nyc/nycInspiration.png" alt="NYC Inspiration" style="width:100%;" /></div>
 
 <div class="nyc-questions">
-  <p class="post-callout">Questions to Answer:</p>
+  <p class="post-callout-large">Questions to Answer:</p>
   <p class="post-callout-small">What are the public (emotional) associations of CMU?</p>
   <p class="post-callout-small"> What is the NYC campus providing? What is its program structure? What will their students receive?</p>
   <p class="post-callout-small">What kind of people does CMU want to attract to their NYC campus?</p>

--- a/_projects/illustrations.markdown
+++ b/_projects/illustrations.markdown
@@ -15,7 +15,7 @@ tags: digital, illustration
     <div class=" medium-6 large-6 cell "><img src="../img/illustrations/popcorncat.gif" alt="Catto + Popcorn" /></div>
 </div>
 
-<p class="post-callout">Check out my <a target="_blank" href="https://instagram.com/naher94">Instagram</a> page for even more illustrations!</p>
+<p class="post-callout-large">Check out my <a target="_blank" href="https://instagram.com/naher94">Instagram</a> page for even more illustrations!</p>
 
 <div class="grid-x grid-padding-x grid-margin-y">
     <div class=" medium-6 large-6 cell "><img src="../img/illustrations/nycity.gif" alt="nycity Lettering" /></div>
@@ -53,7 +53,7 @@ tags: digital, illustration
       <img src="../img/illustrations/kiteMrBond.png" alt="Kite Dancing in a Hurricane Mr. Bond" />
     </div>
     <div class=" medium-6 large-6 cell">
-      <p class="post-callout">"You're a kite dancing in a hurricane Mr. Bond"</p>
+      <p class="post-callout-large">"You're a kite dancing in a hurricane Mr. Bond"</p>
     </div>
 </div>
 <div class="grid-x grid-padding-x grid-margin-y">
@@ -61,7 +61,7 @@ tags: digital, illustration
       <img src="../img/illustrations/followingFollowing.jpg" alt="Map that Leads to You" />
     </div>
     <div class="medium-6 large-6 cell">
-      <p class="post-callout">"The map that leads to you... Following, following, following to you"</p>
+      <p class="post-callout-large">"The map that leads to you... Following, following, following to you"</p>
     </div>
 </div>
 <div class="grid-x grid-padding-x grid-margin-y">

--- a/_projects/photography.markdown
+++ b/_projects/photography.markdown
@@ -15,7 +15,7 @@ tags: photography
     <img style="width:100%" src="../img/photography/kidinatub.jpg" alt="A kid in a tub rowing down the river">
   </div>
 </div>
-<p class="post-callout">Check out my <a target="_blank" href="https://instagram.com/naher94">Instagram</a> page for more of my photography</p>
+<p class="post-callout-large">Check out my <a target="_blank" href="https://instagram.com/naher94">Instagram</a> page for more of my photography</p>
 <div class="grid-x grid-padding-x grid-margin-y">
   <div class="cell medium-6">
     <img style="width:100%" src="../img/photography/twoboats.jpg" alt="2 long river boats in Myanmar">

--- a/_projects/shineregistrybrand.markdown
+++ b/_projects/shineregistrybrand.markdown
@@ -61,7 +61,7 @@ Similarly with the shape language, it was important to give greater contrasts be
   </div>
 </div>
 
-<p class="post-callout">Bringing together the color and shape languages to create this really <strong>sharp</strong>, <strong>natural</strong> and <strong>inviting</strong> tone.</p>
+<p class="post-callout-large">Bringing together the color and shape languages to create this really <strong>sharp</strong>, <strong>natural</strong> and <strong>inviting</strong> tone.</p>
 
 <div class="grid-x grid-padding-x grid-margin-y">
   <div class="cell medium-6">

--- a/brand.html
+++ b/brand.html
@@ -22,6 +22,6 @@ exclude: "true"
   <h3>Header 3</h3>
   <h4>Header 4</h4>
   <p>paragraph tag</p>
-  <p class="post-callout">Post Callout</p>
+  <p class="post-callout-large">Post Callout</p>
   <p><a href="#">this is a link isnt it fun!</a></p>
 </div>


### PR DESCRIPTION
`post-callout` was renamed to `post-callout-large` when `medium` and `small` variants were introduced and some of the locations across the site we missed to be updated. That has now been resolved